### PR TITLE
Use alpine:3.3

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.3
 
 MAINTAINER Laurent Aphecetche <laurent.aphecetche@gmail.com>
 


### PR DESCRIPTION
It fails to build on latest/3.4.
Ref: https://github.com/aphecetche/docker-neovim/issues/1
